### PR TITLE
Fix error in pydicom version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydicom>=2.0<3.0
+pydicom>=2.0,<3.0
 pandas
 numpy
 tqdm


### PR DESCRIPTION
When I install `dicom-csv` via `pip install -e .` in repo or use package from pypi, I get following error:
```
Obtaining file:///Users/pejman/Projects/Labeling/data-registry/dicom-csv
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in dicom_csv setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          pydicom>=2.0<3.0
                 ~~~~~^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```
---
This can be fix by changing `pydicom>=2.0<3.0` to `pydicom>=2.0,<3.0` in **requirements.txt**